### PR TITLE
Remove remaining Paint gem references from codebase

### DIFF
--- a/lib/tint_me/style.rb
+++ b/lib/tint_me/style.rb
@@ -14,7 +14,7 @@ module TIntMe
     :conceal
   )
 
-  # A style class that wraps Paint gem functionality for applying ANSI colors and text effects.
+  # A style class for applying ANSI colors and text effects to terminal output.
   #
   # This class provides an immutable way to define and compose terminal styling options.
   # It supports foreground/background colors, text decorations (bold, italic, underline, etc.),
@@ -137,7 +137,7 @@ module TIntMe
       super
     end
 
-    # Apply the style to the given text using Paint gem
+    # Apply the style to the given text using native ANSI escape sequences
     #
     # @param text [String] The text to apply styling to
     # @return [String] The styled text with ANSI escape codes, or original text if no styles are set

--- a/sig/tint_me.rbs
+++ b/sig/tint_me.rbs
@@ -19,9 +19,9 @@ module TIntMe
     type color_value = :red | :green | :blue | :cyan | :yellow | :magenta | :gray | :white | :black | :default | :reset | String
     type underline_value = bool | :double | :reset
     type boolean_value = bool | :reset
-    type paint_style = :red | :green | :blue | :cyan | :yellow | :magenta | :gray | :white | :black |
-                      :underline | :double_underline | :overline | :bold | :faint | :blink | :italic | :inverse | :conceal |
-                      String | nil
+    type style_attribute = :red | :green | :blue | :cyan | :yellow | :magenta | :gray | :white | :black |
+                          :underline | :double_underline | :overline | :bold | :faint | :blink | :italic | :inverse | :conceal |
+                          String | nil
 
     attr_reader foreground: color_value?
     attr_reader background: color_value?
@@ -57,6 +57,5 @@ module TIntMe
 
     def compose_attribute: ((color_value | underline_value | boolean_value)?, (color_value | underline_value | boolean_value)?) -> (color_value | underline_value | boolean_value)?
 
-    def build_styles: -> Array[paint_style]
   end
 end

--- a/spec/tint_me/style_spec.rb
+++ b/spec/tint_me/style_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe TIntMe::Style do
     end
   end
 
-  describe "Paint gem color compatibility" do
+  describe "color support" do
     it "supports basic color names" do
       expect(TIntMe::Style.new(foreground: :red).call("TEST")).to eq("#{esc}[31mTEST#{esc}[0m")
       expect(TIntMe::Style.new(foreground: :green).call("TEST")).to eq("#{esc}[32mTEST#{esc}[0m")


### PR DESCRIPTION
## Summary

This PR removes all remaining references to the Paint gem from the codebase following the completion of #2. After removing the Paint gem dependency, some documentation and type definitions still mentioned Paint, creating confusion about the current implementation.

### Changes Made

- **📝 Documentation cleanup**: Updated Style class comments to reflect native ANSI implementation
- **🧪 Test descriptions**: Changed "Paint gem compatibility" to "color support" 
- **🏷️ Type definitions**: Updated RBS definitions to remove Paint-specific nomenclature
- **🔧 Method signatures**: Removed obsolete `build_styles` method from RBS (no longer exists in implementation)

### Files Modified

- `lib/tint_me/style.rb`: Updated class and method comments
- `spec/tint_me/style_spec.rb`: Updated test describe block
- `sig/tint_me.rbs`: Cleaned up type definitions and method signatures

### Impact

- **Zero functional changes**: No behavior modifications, only documentation/comments
- **Improved clarity**: All references now accurately reflect the native ANSI implementation
- **Consistent terminology**: Eliminates confusion between old Paint gem approach and current implementation

## Test plan

- [x] All existing tests pass (64 examples, 0 failures)
- [x] 98.09% code coverage maintained
- [x] RuboCop compliance verified
- [x] No functional changes - documentation only

🤖 Generated with [Claude Code](https://claude.ai/code)