### PR TITLE
Replace described_class with explicit class names in tests

### DIFF
--- a/spec/tint_me/sgr_builder_spec.rb
+++ b/spec/tint_me/sgr_builder_spec.rb
@@ -238,14 +238,14 @@ RSpec.describe TIntMe::SGRBuilder do
 
   describe "constants" do
     it "defines expected constants" do
-      expect(described_class::ESC).to eq("\e")
-      expect(described_class::CSI).to eq("\e[")
-      expect(described_class::SGR_END).to eq("m")
-      expect(described_class::RESET_CODE).to eq("\e[0m")
+      expect(TIntMe::SGRBuilder::ESC).to eq("\e")
+      expect(TIntMe::SGRBuilder::CSI).to eq("\e[")
+      expect(TIntMe::SGRBuilder::SGR_END).to eq("m")
+      expect(TIntMe::SGRBuilder::RESET_CODE).to eq("\e[0m")
     end
 
     it "includes all expected colors" do
-      colors = described_class::COLORS
+      colors = TIntMe::SGRBuilder::COLORS
 
       # Standard colors
       expect(colors[:red]).to eq(31)
@@ -271,7 +271,7 @@ RSpec.describe TIntMe::SGRBuilder do
     end
 
     it "includes all expected effects" do
-      effects = described_class::EFFECTS
+      effects = TIntMe::SGRBuilder::EFFECTS
 
       expect(effects[:bold]).to eq(1)
       expect(effects[:faint]).to eq(2)


### PR DESCRIPTION
## Summary

This PR removes remaining `described_class` references from test files to maintain consistency with the project's explicit class naming style.

## Background

Although `RSpec/DescribedClass` is configured to enforce explicit class names (`EnforcedStyle: explicit`), some `described_class` references remained undetected in constant access patterns like `described_class::CONSTANT`. This commit manually removes these remaining instances.

## Changes Made

- **🔧 Constant access patterns**: Replace `described_class::ESC`, `described_class::CSI`, etc. with explicit `TIntMe::SGRBuilder::ESC`, `TIntMe::SGRBuilder::CSI`
- **📋 Consistency improvement**: All test code now uses explicit class references as per project configuration
- **🎯 Manual cleanup**: Address patterns that RuboCop's `RSpec/DescribedClass` rule didn't catch

## Files Modified

- `spec/tint_me/sgr_builder_spec.rb`: Updated 6 constant access references

## Technical Details

### RuboCop Configuration Context
- `RSpec/DescribedClass` is set to `EnforcedStyle: explicit` in project configuration
- Some constant access patterns (`described_class::CONSTANT`) were not detected by the rule
- This manual cleanup ensures complete consistency with the configured style

### Changes Made
```ruby
# Before
expect(described_class::ESC).to eq("\e")
colors = described_class::COLORS

# After  
expect(TIntMe::SGRBuilder::ESC).to eq("\e")
colors = TIntMe::SGRBuilder::COLORS
```

## Impact

- **Zero functional changes**: No behavior modifications, only style consistency
- **Improved clarity**: Explicit class names make test intent clearer
- **Style compliance**: Aligns with project's explicit naming convention

## Test Results

- **64 examples, 0 failures**: All tests pass
- **98.09% coverage**: Code coverage maintained
- **RuboCop clean**: No style violations detected

🤖 Generated with [Claude Code](https://claude.ai/code)