### PR TITLE
:memo: Fix installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@ A Ruby library for terminal text styling with ANSI colors and effects. TIntMe! p
 
 Add this line to your application's Gemfile:
 
+```ruby
+gem "tint_me"
+```
+
+And then execute:
+
 ```bash
-bundle add tint_me
+bundle install
 ```
 
 Or install it yourself as:


### PR DESCRIPTION
## Summary

Corrects the installation instructions in README to show proper Gemfile syntax.

## Changes

- Fixed Gemfile code example from bash command to Ruby code
- Changed from `bundle add tint_me` to `gem "tint_me"` with proper language tag
- Added explicit `bundle install` step after Gemfile modification
- Maintained alternative direct installation option with `gem install`

## Before
```bash
bundle add tint_me
```

## After  
```ruby
gem "tint_me"
```

```bash
bundle install
```

This provides clearer, more standard Ruby gem installation instructions.

:robot: Generated with [Claude Code](https://claude.ai/code)