### PR TITLE
:construction_worker: CI: track latest patch per minor (3.2/3.3/3.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.2.9'
-          - '3.3.9'
-          - '3.4.5'
+          - '3.2'
+          - '3.3'
+          - '3.4'
 
     steps:
       - uses: actions/checkout@v5

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-ruby = "3.2.9"
+ruby = "3.2"
 
 [env]
 _.path = ["bin", "exe"]


### PR DESCRIPTION
## Summary

Align CI matrix and local dev tool with the Ruby support policy.

## Changes

- CI: use minors only (3.2 / 3.3 / 3.4) to always run on latest patches
- Dev: set mise Ruby to 3.2 (oldest supported minor) to match strictest target

## Rationale

- Reduce maintenance (no manual patch bumps)
- Keep CI up-to-date automatically within supported series
- Encourage local development against the strictest supported version

## Checks

- [x] pre-push hook: rubocop/rspec/yard all pass locally
- [x] CI YAML syntax valid
- [x] No unrelated changes included