### PR TITLE
:memo: Docs: add AGENTS.md and RuboCop agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `lib/tint_me`: Core library. Entry point is `lib/tint_me.rb`; code is namespaced under `TIntMe` (autoloaded via Zeitwerk).
+- `spec`: RSpec tests. Mirror library paths (e.g., `spec/tint_me/style_spec.rb`).
+- `docs/api`: Generated YARD documentation. Do not edit by hand; use `rake doc`.
+- `benchmark/*`: Performance experiments and notes.
+- `bin`: Development helpers (`bin/setup`, `bin/console`).
+
+## Build, Test, and Development Commands
+- `bundle install`: Install dependencies (use a supported Ruby; see policy below and `mise.toml`).
+- `rake`: Default task; runs `spec` and `rubocop`.
+- `rake spec`: Run the test suite.
+- `rubocop` or `rake rubocop`: Lint and style checks.
+- `rake doc`: Build YARD docs into `docs/api`.
+- `bin/console`: IRB with the gem loaded for quick experiments.
+- `docquet regenerate-todo`: Regenerate `.rubocop_todo.yml` after lint updates; include with related code fixes.
+
+## Communication & Languages
+- Chat: Use the user's language for AI/maintainer communication.
+- Code & docs: Use English for source, inline comments, README, and YARD docs.
+- Pseudocode in chat: Comments within pseudocode blocks may be in the user's language.
+- Issues/PRs: Prefer English titles and descriptions for broader visibility.
+
+## Coding Style & Naming Conventions
+- Ruby 3.x compatible; 2-space indent, `# frozen_string_literal: true` headers.
+- Follow RuboCop rules (`.rubocop.yml`); fix offenses before committing.
+- Files and specs use snake_case; specs live under `spec/tint_me/*_spec.rb`.
+- Public API is under `TIntMe`; avoid monkey patching. Prefer immutable, composable objects (e.g., `Style` and `>>`).
+- RuboCop fixes: When addressing lints, follow `docs/agents/rubocop.md` (safe autocorrect first; targeted unsafe only as needed).
+
+## Testing Guidelines
+- Framework: RSpec with `spec_helper` and SimpleCov. Maintain ≥ 90% coverage.
+- Name/spec files to mirror library paths; keep examples focused and readable.
+- Run `rake spec` locally; ensure `.rspec_status` is clean.
+
+## Commit & Pull Request Guidelines
+- Title format: Must start with a GitHub `:emoji:` code followed by a space, then an imperative subject. Example: `:zap: Optimize Style#call path`.
+- No raw emoji: Use `:emoji:` codes only (commit hook rejects Unicode emoji).
+- Exceptions: `fixup!` / `squash!` are allowed by hooks.
+- Merge commits: Auto-prefixed with `:inbox_tray:` by the prepare-commit-msg hook.
+- Commit body: English, explaining motivation, approach, and trade-offs.
+- Include rationale and, when useful, before/after snippets or benchmarks.
+- Link issues (e.g., `Fixes #123`) and update README/CHANGELOG when user-facing behavior changes.
+- PRs must pass `rake` (tests + lint), include tests for changes, and keep API docs current (`rake doc` when needed).
+
+## Security & Configuration Tips
+- Supported Ruby: latest patch of the newest three minor series (e.g., 3.4.x / 3.3.x / 3.2.x). Develop locally on the oldest of these.
+- Version management: Use `mise`; the repo’s `mise.toml` sets the default to the oldest supported series. Examples: `mise use -g ruby@3.2`, `mise run -e ruby@3.3 rake spec`.
+- Keep runtime dependencies minimal; prefer standard library where possible.
+- No network access is expected at runtime; avoid introducing it without discussion.

--- a/docs/agents/rubocop.md
+++ b/docs/agents/rubocop.md
@@ -1,0 +1,55 @@
+# RuboCop Fix Workflow for AI Agents
+
+This guide outlines a safe, repeatable process to fix RuboCop offenses while preserving behavior and keeping PRs focused.
+
+## Goals
+- Keep changes minimal and behavior‑preserving; prefer small, focused PRs.
+- Use safe autocorrect first; apply unsafe corrections only when reviewed and covered by tests.
+- Centralize rule changes in `.rubocop.yml`; never hand‑edit `.rubocop_todo.yml`.
+
+## Quick Commands
+- Full lint: `rake rubocop`
+- File/dir lint: `rubocop path/to/file.rb`
+- Safe autocorrect: `rubocop -a`
+- Targeted unsafe: `rubocop -A --only Cop/Name`
+- Run tests: `rake spec`
+- Regenerate TODO: `docquet regenerate-todo`
+ - Temporarily enable a TODO‑disabled cop: comment out its block in `.rubocop_todo.yml`
+
+## Workflow
+1) Reproduce locally
+- Run `rake rubocop` and note failing cops/files.
+
+2) Safe autocorrect first
+- Run `rubocop -a` on specific files or directories to reduce blast radius.
+- Re‑run `rake rubocop` and `rake spec` to verify no behavior changes.
+
+3) Target specific cops (if still failing)
+- For stylistic issues, fix manually or run `rubocop -A --only Cop/Name` on the smallest scope.
+- For logic‑sensitive cops (e.g., Performance, Lint), prefer manual fixes with tests.
+
+3a) If the cop is disabled in `.rubocop_todo.yml`
+- Open `.rubocop_todo.yml`, locate the `Cop/Name` entry, and temporarily comment out (or remove locally) that entire block. RuboCop respects TODO disables even with `--only`, so this is required to surface offenses.
+- Run `rubocop --only Cop/Name` (optionally `-A`) on a narrow path and fix findings.
+- Validate with `rake rubocop` and `rake spec`.
+- Refresh the TODO: run `docquet regenerate-todo` to update/remove the entry based on remaining offenses. Commit code changes and the regenerated `.rubocop_todo.yml` together in the same commit/PR.
+
+4) Update configuration (rare)
+- If a rule conflicts with project style, adjust `.rubocop.yml` with rationale in the PR body.
+- Do not edit `.rubocop_todo.yml` manually. After large cleanups, run `docquet regenerate-todo` and commit only that file.
+
+5) No inline disables
+- Do not use comment-based disables (`# rubocop:disable ...`). This project forbids inline disables.
+- If a finding cannot be safely fixed, pause and ask the maintainer for guidance. Options may include refining the rule in `.rubocop.yml` or adjusting the approach.
+
+6) Validate and commit
+- Ensure `rake` (tests + lint) is green.
+- Commit messages must start with a GitHub `:emoji:` and use imperative mood.
+  Examples:
+  - `:lipstick: RuboCop: safe autocorrect in lib/tint_me/style.rb`
+  - `:rotating_light: RuboCop: fix Lint/UnusedMethodArgument`
+
+## PR Guidance
+- Keep changes small and single‑purpose (e.g., “fix Style/StringLiterals in lib/tint_me”).
+- Include before/after snippets if unsafe autocorrect or refactor was applied.
+- Link any rule changes to rationale and project conventions.


### PR DESCRIPTION
## Summary

Add contributor guidance and an agent-focused RuboCop fix workflow.

## Changes

- Add `AGENTS.md`: concise repository guidelines (structure, build/test, coding style, testing, commits/PRs, language policy, Ruby support, and RuboCop TODO regeneration).
- Add `docs/agents/rubocop.md`: safe, practical flow for addressing RuboCop offenses, including handling cops disabled in `.rubocop_todo.yml` and using `docquet regenerate-todo`.

## Rationale

- Provide clear, actionable guidance for contributors and AI agents while keeping the README focused.
- Standardize lint-fix workflow to keep PRs safe and reviewable.

## Checks

- [x] Pre-push hooks: rubocop/rspec/yard pass locally
- [x] No runtime code changes included
- [x] Matches project commit and language policies