### PR TITLE
:memo: Enhance AGENTS.md with documentation references and symlink note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # Repository Guidelines
 
+> **Note**: This file is also accessible via the `CLAUDE.md` symlink for AI agent compatibility.
+
+> **Important**: This document references other documentation files. Please also read:
+> - `docs/agents/rubocop.md` - RuboCop fix guidelines for AI agents
+> - Any other documents referenced inline below
+
 ## Project Structure & Module Organization
 - `lib/tint_me`: Core library. Entry point is `lib/tint_me.rb`; code is namespaced under `TIntMe` (autoloaded via Zeitwerk).
 - `spec`: RSpec tests. Mirror library paths (e.g., `spec/tint_me/style_spec.rb`).


### PR DESCRIPTION
## Summary

Enhance AGENTS.md with clear documentation structure and symlink information.

## Changes

1. **Add symlink note**: Document that AGENTS.md is accessible via CLAUDE.md symlink
2. **Add reference instruction**: Prominent notice to read all referenced documentation
3. **Highlight RuboCop guide**: Specific mention of `docs/agents/rubocop.md`

## Purpose

- Improve AI agent onboarding experience
- Ensure comprehensive understanding of project conventions
- Make the relationship between AGENTS.md and CLAUDE.md explicit
- Guide agents to read all necessary documentation

## Documentation Structure

```
AGENTS.md (main file) 
    └── CLAUDE.md (symlink for compatibility)
    └── References:
        └── docs/agents/rubocop.md
```

:robot: Generated with [Claude Code](https://claude.ai/code)