### PR TITLE
:memo: Correct caching vs pre-computation terminology

### DIFF
--- a/lib/tint_me/style.rb
+++ b/lib/tint_me/style.rb
@@ -134,7 +134,7 @@ module TIntMe
         raise ArgumentError, "Cannot specify both bold and faint simultaneously"
       end
 
-      # Pre-calculate and cache SGR sequences before freezing
+      # Pre-compute SGR sequences before freezing
       # (Data.define freezes the instance after super)
       sgr_builder = self.class.sgr_builder
 
@@ -164,7 +164,7 @@ module TIntMe
         overline: overline == true ? true : nil
       )
 
-      # Cache reset code
+      # Pre-compute reset code
       @reset_code = sgr_builder.reset_code
 
       super


### PR DESCRIPTION
## Summary
Correct terminology from "caching" to "pre-computation" throughout documentation and code comments for technical accuracy.

## Changes
- **README.md**: Replace "SGR sequence caching" with "SGR sequence pre-computation"
  - Update performance documentation terminology
  - Clarify "define once, use many" pattern with initialization-time computation
- **lib/tint_me/style.rb**: Correct initialization comments
  - "Pre-calculate and cache" → "Pre-compute"
  - "Cache reset code" → "Pre-compute reset code"

## Technical Rationale
The current implementation performs **pre-computation at initialization time**, not runtime caching:

```ruby
def initialize(...)
  @prefix = sgr_builder.prefix_codes(...)  # Computed once at creation
  @reset_code = sgr_builder.reset_code
end

def call(text)
  "#{@prefix}#{text}#{@reset_code}"       # Uses pre-computed values
end
```

This is technically a form of **memoization** (specifically initialization-time memoization) rather than traditional caching which implies storage/retrieval across multiple calls or instances.

## Benefits
- **Technical accuracy**: Terminology now matches implementation
- **Clearer understanding**: Users better understand the optimization mechanism
- **Consistent documentation**: Unified terminology across codebase
