### PR TITLE
:wrench: Fix GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -17,6 +17,9 @@ env:
 jobs:
   create-release-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # Required for git push (branch and tag creation)
+      pull-requests: write  # Required for PR creation
 
     steps:
     - name: Checkout code

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -15,6 +15,8 @@ jobs:
   publish-release:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release-v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # Required for GitHub Release creation and branch deletion
 
     steps:
     - name: Extract version from branch name

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -15,7 +15,9 @@ jobs:
     # Only run for release branches
     if: startsWith(github.head_ref, 'release-v')
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: write      # Required for git tag push
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
@@ -105,14 +107,14 @@ jobs:
       if: github.event.action == 'synchronize'  # When new commits are pushed to PR
       run: |
         echo "Updating tag v${{ steps.version.outputs.version }} to latest commit"
-        
+
         # Force update the tag to current HEAD
         git tag -fa "v${{ steps.version.outputs.version }}" \
           -m "Release v${{ steps.version.outputs.version }}"
-        
+
         # Force push the updated tag
         git push origin "v${{ steps.version.outputs.version }}" --force
-        
+
         echo "🏷️ Tag v${{ steps.version.outputs.version }} updated to commit $(git rev-parse --short HEAD)"
 
     - name: Release validation summary


### PR DESCRIPTION
Fix 403 permission errors in release workflows by adding required permissions.

## Changes

- **release-preparation.yml**: Add `contents:write` and `pull-requests:write` permissions for git push operations and PR creation
- **release-validation.yml**: Add `contents:write` permission for git tag force push operations  
- **release-publish.yml**: Add `contents:write` permission for GitHub Release creation and branch deletion

## Problem

Release workflows were failing with 403 permission errors when attempting to:
- Push release branches and tags
- Create pull requests  
- Create GitHub releases
- Delete release branches

## Solution

Added job-level permissions following the principle of least privilege. Each job only receives the minimal permissions required for its specific operations.

:robot: Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>