### PR TITLE
:wrench: Improve release workflow branch cleanup

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -95,9 +95,14 @@ jobs:
           --notes-file release_notes.md \
           pkg/${{ env.GEM_NAME }}-${{ steps.version.outputs.version }}.gem
 
-    - name: Cleanup release branch
+    - name: Cleanup release branch (if exists)
       run: |
-        git push origin --delete release-v${{ steps.version.outputs.version }}
+        if git ls-remote --heads origin release-v${{ steps.version.outputs.version }} | grep -q release-v${{ steps.version.outputs.version }}; then
+          echo "Deleting release branch: release-v${{ steps.version.outputs.version }}"
+          git push origin --delete release-v${{ steps.version.outputs.version }}
+        else
+          echo "Release branch already deleted (likely by auto-delete setting)"
+        fi
       continue-on-error: true
 
     - name: Post-release summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Development
+- Improved release workflow branch cleanup with existence check
+
 ## [1.0.0] - 2025-09-09
 
 ### Added


### PR DESCRIPTION
Fix branch cleanup error in release workflow when GitHub auto-delete is enabled.

## Problem

The release workflow failed with this error during branch cleanup:
```
error: unable to delete 'release-v1.0.0': remote ref does not exist
```

This occurs when GitHub's "Automatically delete head branches" setting removes the release branch immediately after PR merge, but the workflow still tries to delete it.

## Solution

Add existence check before attempting branch deletion:
- Check if release branch exists using `git ls-remote`
- Only attempt deletion if branch exists
- Provide informative messages for both scenarios

## Changes

- **release-publish.yml**: Add branch existence check before cleanup
- **CHANGELOG.md**: Document workflow improvement

:robot: Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>