### PR TITLE
:memo: Fix color terminology in SGR builder documentation

### DIFF
--- a/lib/tint_me/sgr_builder.rb
+++ b/lib/tint_me/sgr_builder.rb
@@ -97,7 +97,7 @@ module TIntMe
     #   prefix_codes(foreground: :red, bold: true)
     #   # => "\e[31;1m"
     #
-    # @example 256-color RGB (true color)
+    # @example RGB true color (24-bit)
     #   prefix_codes(foreground: "#FF6B35", background: "#F7931E")
     #   # => "\e[38;2;255;107;53;48;2;247;147;30m"
     #


### PR DESCRIPTION
Correct misleading color terminology in code documentation.

## Problem

The comment in `sgr_builder.rb` incorrectly stated:
```ruby
# @example 256-color RGB (true color)
```

This conflated two distinct ANSI color modes:
- **256-color mode**: 8-bit color (256 total colors)
- **RGB true color**: 24-bit color (16.7 million colors)

## Solution

Updated to accurate terminology:
```ruby
# @example RGB true color (24-bit)
```

## Impact

- More accurate technical documentation
- Prevents confusion between 8-bit and 24-bit color modes
- Better developer understanding of ANSI color capabilities

:robot: Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>