### PR TITLE
:memo: Update release documentation to reflect GitHub Actions workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ puts style.("Hello")                  # Callable syntax
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb` and update the CHANGELOG.md, then create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org). However, there are GitHub Actions workflows set up to automate these processes, so please use those instead. See `RELEASING.md` for details.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Updates the Development section in README.md to reflect the actual release process used by this project.

## Changes

- Replace outdated `bundle exec rake release` instruction with acknowledgment of GitHub Actions workflows
- Add reference to `RELEASING.md` for detailed release instructions
- Maintain information about manual release steps while directing users to automated workflows

## Background

The current README suggests using `bundle exec rake release` for releases, but this project has sophisticated GitHub Actions workflows for automated releases via `release-v{VERSION}` branches. This update ensures documentation accuracy and guides contributors to the preferred release method.

## Test Plan

- [x] Documentation change only - no functional impact
- [x] Reviewed current GitHub Actions workflows to ensure accuracy
- [x] Verified reference to RELEASING.md is appropriate

:robot: Generated with [Claude Code](https://claude.ai/code)