### PR TITLE
:wrench: Add require: false to SimpleCov gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,5 +31,5 @@ end
 group :test do
   # RSpec & SimpleCov
   gem "rspec"
-  gem "simplecov"
+  gem "simplecov", require: false
 end


### PR DESCRIPTION
## Summary
- Add `require: false` to SimpleCov gem dependency to prevent automatic loading when bundle is loaded
- Allows SimpleCov to be explicitly required only in test environments
- Follows Ruby gem best practices for test-only dependencies

## Test plan
- [x] All tests pass
- [x] RuboCop checks pass
- [x] SimpleCov still works correctly when explicitly required in test environment

:robot: Generated with [Claude Code](https://claude.ai/code)